### PR TITLE
feat(extention): Change regex logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
         },
         "mathover.matchRegex": {
           "title": "Match Regex",
-          "default": "#\\sMath:\\s(.+)",
+          "default": "(?<prefix>(\\/{2,}|#)\\s+Math:\\s)(?<expression>.+)",
           "type": "string",
           "description": "Regex to match math section."
         },
@@ -69,12 +69,6 @@
           "default": "g",
           "type": "string",
           "description": "Flags for regex to match wrong syntax."
-        },
-        "mathover.forwardSkip": {
-          "title": "Forward Skip",
-          "default": 8,
-          "type": "number",
-          "description": "Number of characters to skip from the beginning of the match."
         },
         "mathover.backwardSkip": {
           "title": "Backward Skip",

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,7 +7,7 @@ export default {
 	matchRegFlags: <string>workspace.getConfiguration().get("mathover.matchRegexFlags"),
 	wrongReg: <string>workspace.getConfiguration().get("mathover.wrongRegex"),
 	wrongRegFlags: <string>workspace.getConfiguration().get("mathover.wrongRegexFlags"),
-	forwardSkip: <number>workspace.getConfiguration().get("mathover.forwardSkip"),
+	//forwardSkip: <number>workspace.getConfiguration().get("mathover.forwardSkip"),
 	backwardSkip: <number>workspace.getConfiguration().get("mathover.backwardSkip"),
 	cacheSize: <number>workspace.getConfiguration().get("mathover.cacheSize"),
 	updateInterval: <number>workspace.getConfiguration().get("mathover.updateInterval"),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,20 +20,22 @@ export function activate(context: vscode.ExtensionContext) {
 		const correctUsage: vscode.DecorationOptions[] = [];
 		let match;
 		while ((match = matchRegEx.exec(text))) {
-			const start = match.index + config.forwardSkip;
-			const end = match.index + match[0].length - config.backwardSkip;
-			const startPos = activeEditor.document.positionAt(start);
-			const endPos = activeEditor.document.positionAt(end);
-			const range = new vscode.Range(startPos, endPos);
-			const latex = match[0].substring(config.forwardSkip, match[0].length - config.backwardSkip);
-			// console.log(`Match: ${match[0]}, match index: ${match.index}, match length: ${match[0].length}, processed: ${latex}`);
-			const hoverUri = await tex2Svg.render(latex);
-			const decoration = { range: range, hoverMessage: hoverUri.text };
-
-			if (hoverUri.error || wrongRegEx.test(match[0])) {
-				wrongUsage.push(decoration);
-			} else {
-				correctUsage.push(decoration);
+			const groups = (match.groups || {})
+			if (('prefix' in groups) && ('expression' in groups)) {
+				const start = match.index + groups.prefix.length;
+				const end = match.index + match[0].length - config.backwardSkip;
+				const startPos = activeEditor.document.positionAt(start);
+				const endPos = activeEditor.document.positionAt(end);
+				const range = new vscode.Range(startPos, endPos);
+				const latex = groups.expression;
+				// console.log(`Match: ${match[0]}, match index: ${match.index}, match length: ${match[0].length}, processed: ${latex}`);
+				const hoverUri = await tex2Svg.render(latex);
+				const decoration = { range: range, hoverMessage: hoverUri.text };
+				if (hoverUri.error || wrongRegEx.test(match[0])) {
+					wrongUsage.push(decoration);
+				} else {
+					correctUsage.push(decoration);
+				}
 			}
 		}
 		activeEditor.setDecorations(config.wrongDecorationType, wrongUsage);

--- a/src/tex2svg.ts
+++ b/src/tex2svg.ts
@@ -48,7 +48,8 @@ export class Tex2Svg {
 			});
 		} catch (err) {
 			// vscode.window.showWarningMessage(err);
-			return { text: err, error: true }; // return the string
+			let error_msg = (String(err) || '')
+			return { text: error_msg, error: true }; // return the string
 		}
 
 		let svg = data?.svg;


### PR DESCRIPTION
To improve the scalability of regular expressions, the group functionality was used.

Now the user specifies two groups in the regular expression: 'prefix' and 'expression'.

This allows you to construct regular expressions to capture a mathematical expression without having to explicitly specify the indent length.